### PR TITLE
adds new functions which retrieve the current state of counters and strings

### DIFF
--- a/cnxeasybake/tests/html/debug_current.log
+++ b/cnxeasybake/tests/html/debug_current.log
@@ -1,0 +1,26 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (1): body * 
+cnx-easybake DEBUG     default: counter-increment counterName
+cnx-easybake DEBUG     default: counter-increment counterDoubleName 2
+cnx-easybake DEBUG     default: string-set stringName "val=" counter(counterName)
+cnx-easybake DEBUG     default: string-set stringDoubleName "val=" counter(counterDoubleName)
+cnx-easybake DEBUG Rule (7): body * 
+cnx-easybake DEBUG     default: attr-data-counters debug-current-counters()
+cnx-easybake DEBUG     default: attr-data-strings debug-current-strings()
+cnx-easybake DEBUG Rule (1): body * 
+cnx-easybake DEBUG     default: counter-increment counterName
+cnx-easybake DEBUG     default: counter-increment counterDoubleName 2
+cnx-easybake DEBUG     default: string-set stringName "val=" counter(counterName)
+cnx-easybake DEBUG     default: string-set stringDoubleName "val=" counter(counterDoubleName)
+cnx-easybake DEBUG Rule (7): body * 
+cnx-easybake DEBUG     default: attr-data-counters debug-current-counters()
+cnx-easybake DEBUG     default: attr-data-strings debug-current-strings()
+cnx-easybake DEBUG Rule (1): body * 
+cnx-easybake DEBUG     default: counter-increment counterName
+cnx-easybake DEBUG     default: counter-increment counterDoubleName 2
+cnx-easybake DEBUG     default: string-set stringName "val=" counter(counterName)
+cnx-easybake DEBUG     default: string-set stringDoubleName "val=" counter(counterDoubleName)
+cnx-easybake DEBUG Rule (7): body * 
+cnx-easybake DEBUG     default: attr-data-counters debug-current-counters()
+cnx-easybake DEBUG     default: attr-data-strings debug-current-strings()
+cnx-easybake DEBUG Recipe default length: 9

--- a/cnxeasybake/tests/html/debug_current_baked.html
+++ b/cnxeasybake/tests/html/debug_current_baked.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>debug-current-counters() and debug-current-strings()</title>
+</head>
+<body>
+  <div data-counters="{u'counterName': 1, u'counterDoubleName': 2}" data-strings="{u'stringName': u'val=1', u'stringDoubleName': u'val=2'}"></div>
+  <div data-counters="{u'counterName': 2, u'counterDoubleName': 4}" data-strings="{u'stringName': u'val=2', u'stringDoubleName': u'val=4'}"></div>
+  <div data-counters="{u'counterName': 3, u'counterDoubleName': 6}" data-strings="{u'stringName': u'val=3', u'stringDoubleName': u'val=6'}"></div>
+</body>
+</html>

--- a/cnxeasybake/tests/html/debug_current_raw.html
+++ b/cnxeasybake/tests/html/debug_current_raw.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>debug-current-counters() and debug-current-strings()</title>
+</head>
+<body>
+  <div/>
+  <div/>
+  <div/>
+</body>
+</html>

--- a/cnxeasybake/tests/rulesets/debug_current.css
+++ b/cnxeasybake/tests/rulesets/debug_current.css
@@ -1,0 +1,10 @@
+body * {
+  counter-increment: counterName;
+  counter-increment: counterDoubleName 2;
+  string-set: stringName "val=" counter(counterName);
+  string-set: stringDoubleName "val=" counter(counterDoubleName);
+}
+body * {
+  attr-data-counters: debug-current-counters();
+  attr-data-strings: debug-current-strings();
+}


### PR DESCRIPTION
This allows you to annotate the DOM with the current values of all the counters and strings to see what is happening.

Example CSS:

```css
/* this block is boilerplate for the test */
body * {
  counter-increment: counterName;
  counter-increment: counterDoubleName 2;
  string-set: stringName "val=" counter(counterName);
  string-set: stringDoubleName "val=" counter(counterDoubleName);
}

body * {
  attr-data-counters: debug-current-counters();
  attr-data-strings: debug-current-strings();
}
```

Output HTML:

```html
<body>
  <div data-counters="{u'counterName': 1, u'counterDoubleName': 2}" data-strings="{u'stringName': u'val=1', u'stringDoubleName': u'val=2'}"></div>
  <div data-counters="{u'counterName': 2, u'counterDoubleName': 4}" data-strings="{u'stringName': u'val=2', u'stringDoubleName': u'val=4'}"></div>
</body>
```

The test should probably be expanded to multiple passes, looking up a counter that was set on a parent element (to ensure the counter value is cascading down)

/cc @helenemccarron @zroehr @InconceivableVizzini to see if this feature is useful