### PR TITLE
allows adding custom log messages for debugging rulesets

### DIFF
--- a/cnxeasybake/tests/html/debug_log_message.log
+++ b/cnxeasybake/tests/html/debug_log_message.log
@@ -1,0 +1,10 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (1): body * 
+cnx-easybake DEBUG     default: counter-increment counterName
+cnx-easybake DEBUG     default: debug-log "CUSTOM_LOG_MESSAGE" counter(counterName)
+cnx-easybake WARNING CUSTOM_LOG_MESSAGE(1,)
+cnx-easybake DEBUG Rule (1): body * 
+cnx-easybake DEBUG     default: counter-increment counterName
+cnx-easybake DEBUG     default: debug-log "CUSTOM_LOG_MESSAGE" counter(counterName)
+cnx-easybake WARNING CUSTOM_LOG_MESSAGE(2,)
+cnx-easybake DEBUG Recipe default length: 1

--- a/cnxeasybake/tests/html/debug_log_message_baked.html
+++ b/cnxeasybake/tests/html/debug_log_message_baked.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>Debug Log Message</title>
+</head>
+<body>
+  <div></div>
+  <div></div>
+</body>
+</html>

--- a/cnxeasybake/tests/html/debug_log_message_raw.html
+++ b/cnxeasybake/tests/html/debug_log_message_raw.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>Debug Log Message</title>
+</head>
+<body>
+  <div/>
+  <div/>
+</body>
+</html>

--- a/cnxeasybake/tests/rulesets/debug_log_message.css
+++ b/cnxeasybake/tests/rulesets/debug_log_message.css
@@ -1,0 +1,4 @@
+body * {
+  counter-increment: counterName;
+  debug-log: "CUSTOM_LOG_MESSAGE" counter(counterName);
+}


### PR DESCRIPTION
easybake provides detailed log messages which are useful for debugging easybake but not as useful for debugging the recipes. This adds a declaration that allows developers to create a custom message.

I am mostly posting this to see if there is interest before cleaning the code up and testing.

Example CSS:

```css
body * {
  counter-increment: counterName;
  debug-log: "CUSTOM_LOG_MESSAGE" counter(counterName);
}
```

# TODO

- [ ] the code is copy/pasta'd code that handles the `content: ` declaration it should probably be refactored to reuse more code (like a visitor pattern or something)
- [ ] all functions should be tested (like `string()`, `pending()`, and maybe even `target-counter()`

/cc @helenemccarron @zroehr @InconceivableVizzini to see if this feature is useful