### PR TITLE
Adds support for cascading declarations

### DIFF
--- a/cnxeasybake/tests/html/multiple_declarations.log
+++ b/cnxeasybake/tests/html/multiple_declarations.log
@@ -1,0 +1,30 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (8): p.pair1 
+cnx-easybake DEBUG     default: counter-increment c3 1
+cnx-easybake DEBUG Rule (1): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG     default: counter-increment c1 1
+cnx-easybake DEBUG Rule (8): p.pair1 
+cnx-easybake DEBUG     default: counter-increment c3 1
+cnx-easybake DEBUG Rule (1): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG     default: counter-increment c1 1
+cnx-easybake DEBUG Rule (11): .pair2 
+cnx-easybake DEBUG     default: counter-increment c4 1
+cnx-easybake DEBUG Rule (1): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG     default: counter-increment c1 1
+cnx-easybake DEBUG Rule (11): .pair2 
+cnx-easybake DEBUG     default: counter-increment c4 1
+cnx-easybake DEBUG Rule (1): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG Rule (2): p::before 
+cnx-easybake DEBUG     default: counter-increment c1 1
+cnx-easybake DEBUG Rule (5): ol, ol 
+cnx-easybake DEBUG     default: counter-increment c2 1
+cnx-easybake DEBUG Rule (14): #actual 
+cnx-easybake DEBUG     default: content counter(c1) ", " counter(c2) ", " counter(c3) ", " counter(c4)
+cnx-easybake DEBUG Recipe default length: 9

--- a/cnxeasybake/tests/html/multiple_declarations_baked.html
+++ b/cnxeasybake/tests/html/multiple_declarations_baked.html
@@ -6,10 +6,10 @@
 <p class="cls pair2">c</p>
 <p class="cls pair2">d</p>
 
-<ol/>
+<ol></ol>
 
 <div>Expected: 4, 1, 2, 2
-     Actual: <span id="actual"/></div>
+     Actual: <span id="actual">4, 1, 2, 2</span></div>
 
 </body>
 </html>

--- a/cnxeasybake/tests/html/multiple_declarations_raw.html
+++ b/cnxeasybake/tests/html/multiple_declarations_raw.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+
+<p>a</p>
+<p>b</p>
+<p>c</p>
+
+<ol/>
+
+<div>Expected: 3, 1
+     Actual: <span id="actual"/></div>
+
+</body>
+</html>

--- a/cnxeasybake/tests/html/multiple_declarations_raw.html
+++ b/cnxeasybake/tests/html/multiple_declarations_raw.html
@@ -1,13 +1,13 @@
 <html>
 <body>
 
-<p>a</p>
-<p>b</p>
-<p>c</p>
+<p class="cls a">a</p>
+<p class="cls b">b</p>
+<p class="cls c">c</p>
 
 <ol/>
 
-<div>Expected: 3, 1
+<div>Expected: 3, 1, 3, 3
      Actual: <span id="actual"/></div>
 
 </body>

--- a/cnxeasybake/tests/rulesets/multiple_declarations.css
+++ b/cnxeasybake/tests/rulesets/multiple_declarations.css
@@ -5,10 +5,10 @@ ol,
 ol { counter-increment: c2 1; }
 
 
-p.cls { counter-increment: c3 1; }
-.cls { counter-increment: c3 100000; }
+p.pair1 { counter-increment: c3 1; }
+.pair1 { counter-increment: c3 100000; }
 
-.cls { counter-increment: c4 1 !important; }
-p.cls { counter-increment: c4 100000; }
+.pair2 { counter-increment: c4 1 !important; }
+p.pair2 { counter-increment: c4 100000; }
 
 #actual { content: counter(c1) ', ' counter(c2) ', ' counter(c3) ', ' counter(c4); }

--- a/cnxeasybake/tests/rulesets/multiple_declarations.css
+++ b/cnxeasybake/tests/rulesets/multiple_declarations.css
@@ -1,0 +1,8 @@
+p::before { counter-increment: c1 100000; }
+p::before { counter-increment: c1 1; }
+
+ol,
+ol { counter-increment: c2 1; }
+
+
+#actual { content: counter(c1) ', ' counter(c2); }

--- a/cnxeasybake/tests/rulesets/multiple_declarations.css
+++ b/cnxeasybake/tests/rulesets/multiple_declarations.css
@@ -5,4 +5,10 @@ ol,
 ol { counter-increment: c2 1; }
 
 
-#actual { content: counter(c1) ', ' counter(c2); }
+p.cls { counter-increment: c3 1; }
+.cls { counter-increment: c3 100000; }
+
+.cls { counter-increment: c4 1 !important; }
+p.cls { counter-increment: c4 100000; }
+
+#actual { content: counter(c1) ', ' counter(c2) ', ' counter(c3) ', ' counter(c4); }


### PR DESCRIPTION
For example, after parsing a document containing only `<body><p class="cls"/><ol/></body>` all counters (`c1` through `c5`) should have a value of 1. They currently have values of `100001`, `100001`, `2`, `100001`, `100001`.

```css
p {
  counter-increment: c1 100000;
  counter-increment: c1 1;
}

p { counter-increment: c2 100000; }
p { counter-increment: c2 1; }

ol,
ol { counter-increment: c3 1; }


p.cls { counter-increment: c4 1; }
.cls { counter-increment: c4 100000; }

.cls { counter-increment: c5 1 !important; }
p.cls { counter-increment: c5 100000; }
```

This PR may also eventually change the declaration evaluation order. /cc @InconceivableVizzini 


To see what the existing tests would look like when CSS declarations are applied using CSS Specificity, [click here](https://github.com/Connexions/cnx-easybake/compare/add-cascading...cascading-repercussions) (**Note:** most of these could be fixed by slightly changing the semantics of `::before`)