### PR TITLE
Recognize error from deletion on '::outside'

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -1434,8 +1434,9 @@ def grouped_insert(t, value):
             parent = target_parent_descendants[0]
             parent.insert(parent.index(t.tree), value)
             value.append(t.tree)
-        except IndexError:
-            logger.warning('Target of outside has been moved or deleted')
+        except IndexError as e:
+            logger.error('Target of outside has been moved or deleted')
+            raise e
 
     elif t.location == 'before':
         value.tail = t.tree.text

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -1428,10 +1428,14 @@ def grouped_insert(t, value):
     elif t.location == 'outside':
         value.tail = t.tree.tail
         t.tree.tail = None
-        parent = [n.getparent() for n in t.parent.iterdescendants()
-                  if n == t.tree][0]
-        parent.insert(parent.index(t.tree), value)
-        value.append(t.tree)
+        target_parent_descendants = (
+            [n.getparent() for n in t.parent.iterdescendants() if n == t.tree])
+        try:
+            parent = target_parent_descendants[0]
+            parent.insert(parent.index(t.tree), value)
+            value.append(t.tree)
+        except IndexError:
+            logger.warning('Target of outside has been moved or deleted')
 
     elif t.location == 'before':
         value.tail = t.tree.text


### PR DESCRIPTION
Handles issue #90. Easybake will now recognize the strange behavior rather than erroring and exiting from what is technically valid input.

**Copied from my explanation on the issue.**

> A short example of what causes failure:
> This markup
> ```html
> <html>
>   <div class="select-me">
>     <span>Text</span>
>   </div>
> </html>
> ```
> baked with
> ```css
> .select-me::outside { content: pending(empty-bucket); }
> .select-me::outside { content: content(); }
> ```
> yields the same error. After the first `::outside`, `.select-me` is removed from its parent because its content was set to an empty group. On the second `::outside`, `.select-me`'s parent is found, but it no longer has `.select-me` as a descendant, causing an IndexError. The change in PR #91 catches and warns about this behavior.