### PR TITLE
Add tests for unquoted escape character removal in :match

### DIFF
--- a/cnxeasybake/tests/html/match_escape.log
+++ b/cnxeasybake/tests/html/match_escape.log
@@ -1,0 +1,189 @@
+cnx-easybake DEBUG Passes: ['0', u'2', u'3']
+cnx-easybake DEBUG Rule (2): div[data-type="page"] > div[data-type="document-title"] 
+cnx-easybake DEBUG     0: string-set section-title content()
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Rule (8): div[data-type="page"] span[data-type="term"]:match(\^[\^a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by ""
+cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 
+cnx-easybake DEBUG     0: attr-group-by first-letter(content())
+cnx-easybake DEBUG Recipe 0 length: 16
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (11): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content content()
+cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
+cnx-easybake DEBUG     2: container span
+cnx-easybake DEBUG     2: class glossary-term
+cnx-easybake DEBUG IdentToken as string: glossary-term
+cnx-easybake DEBUG     2: move-to gloss-term
+cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
+cnx-easybake DEBUG     2: container a
+cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
+cnx-easybake DEBUG     2: move-to link
+cnx-easybake DEBUG Rule (24): div[data-type="page"] span[data-type="term"]:pass(2)::after 
+cnx-easybake DEBUG     2: content pending(gloss-term) pending(link)
+cnx-easybake DEBUG     2: class glossary-item
+cnx-easybake DEBUG IdentToken as string: glossary-item
+cnx-easybake DEBUG     2: move-to eob-glossary
+cnx-easybake DEBUG Rule (29): body:pass(2)::after 
+cnx-easybake DEBUG     2: class glossary
+cnx-easybake DEBUG IdentToken as string: glossary
+cnx-easybake DEBUG     2: content pending(eob-glossary)
+cnx-easybake DEBUG     2: group-by span, "span::attr(group-by)", nocase
+cnx-easybake DEBUG Recipe 2 length: 140
+cnx-easybake DEBUG Rule (34): body > div.glossary > div.group-by:first-of-type > span.group-label:pass(3) 
+cnx-easybake DEBUG     3: content "Symbol"
+cnx-easybake DEBUG Recipe 3 length: 3

--- a/cnxeasybake/tests/html/match_escape_baked.html
+++ b/cnxeasybake/tests/html/match_escape_baked.html
@@ -1,0 +1,51 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Terms, terms and more terms</title>
+
+</head>
+<body data-type="book">
+<div data-type="chapter">
+    <div data-type="page">
+        <div data-type="document-title">Drinks and Hydration</div> 
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section</p>
+        </section>
+        <h1>Drinks!</h1>
+            <dl class="definition">
+                <dt>Water</dt>
+                <dd>An important drink: stay hydrated!</dd>
+            </dl>
+            <dl class="definition">
+                <dt>Coffee</dt>
+                <dd>That with out which I would not be awake</dd>
+            </dl>
+            <dl class="definition">
+                <dt>Milk</dt>
+                <dd>Cow juice</dd>
+            </dl>
+        <p>The <span data-type="term" id="idterm1" group-by="d">drinks</span> listed above are all
+        important in maintaining <span data-type="term" id="idterm2" group-by="h">hydration</span>,
+        no matter what your age. Some people think that since <span data-type="term" id="idterm3" group-by="c">coffee</span>
+        contains <span data-type="term" id="idterm4" group-by="c">caffeine</span>, which is a
+        <span data-type="term" id="idterm5" group-by="d">diuretic</span>, that drinking coffee itself is
+        <span data-type="term" id="idterm6" group-by="d"><em>de</em>hydrating</span>. Caffeine has no affect
+        on <span data-type="term" group-by="">&#120572;-adenurgic receptors</span>. In reality, coffee is dilute enough
+        that it provides a net positive <span data-type="term" id="idterm7" group-by="h">hydration</span>.</p>
+
+        <p>Stuff not in a section, should stay in chapter.</p>
+        <section class="this one doesn't move">
+            <p>Stuff that stays, as well</p>
+            <section class="key-equations">
+                <p>Hi, I'm a key equation</p>
+            </section>
+        </section>
+    </div>
+    <div data-type="page">
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section, too</p>
+        </section>
+    </div>
+</div>
+<div class="glossary"><div class="group-by"><span class="group-label">Symbol</span><div class="glossary-item"><span group-by="" class="glossary-term">&#120572;-adenurgic receptors</span><a href="#">Drinks and Hydration</a></div></div><div class="group-by"><span class="group-label">C</span><div class="glossary-item"><span group-by="c" class="glossary-term">caffeine</span><a href="#idterm4">Drinks and Hydration</a></div><div class="glossary-item"><span group-by="c" class="glossary-term">coffee</span><a href="#idterm3">Drinks and Hydration</a></div></div><div class="group-by"><span class="group-label">D</span><div class="glossary-item"><span group-by="d" class="glossary-term"><em>de</em>hydrating</span><a href="#idterm6">Drinks and Hydration</a></div><div class="glossary-item"><span group-by="d" class="glossary-term">diuretic</span><a href="#idterm5">Drinks and Hydration</a></div><div class="glossary-item"><span group-by="d" class="glossary-term">drinks</span><a href="#idterm1">Drinks and Hydration</a></div></div><div class="group-by"><span class="group-label">H</span><div class="glossary-item"><span group-by="h" class="glossary-term">hydration</span><a href="#idterm2">Drinks and Hydration</a><a href="#idterm7">Drinks and Hydration</a></div></div></div></body>
+</html>

--- a/cnxeasybake/tests/html/match_escape_raw.html
+++ b/cnxeasybake/tests/html/match_escape_raw.html
@@ -1,0 +1,51 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<title>Terms, terms and more terms</title>
+
+</head>
+<body data-type="book">
+<div data-type="chapter">
+    <div data-type="page">
+        <div data-type="document-title">Drinks and Hydration</div> 
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section</p>
+        </section>
+        <h1>Drinks!</h1>
+            <dl class="definition">
+                <dt>Water</dt>
+                <dd>An important drink: stay hydrated!</dd>
+            </dl>
+            <dl class="definition">
+                <dt>Coffee</dt>
+                <dd>That with out which I would not be awake</dd>
+            </dl>
+            <dl class="definition">
+                <dt>Milk</dt>
+                <dd>Cow juice</dd>
+            </dl>
+        <p>The <span data-type="term" id="idterm1">drinks</span> listed above are all
+        important in maintaining <span data-type="term" id="idterm2">hydration</span>,
+        no matter what your age. Some people think that since <span data-type="term" id="idterm3">coffee</span>
+        contains <span data-type="term" id="idterm4">caffeine</span>, which is a
+        <span data-type="term" id="idterm5">diuretic</span>, that drinking coffee itself is
+        <span data-type="term" id="idterm6"><em>de</em>hydrating</span>. Caffeine has no affect
+        on <span data-type="term">𝛼-adenurgic receptors</span>. In reality, coffee is dilute enough
+        that it provides a net positive <span data-type="term" id="idterm7">hydration</span>.</p>
+
+        <p>Stuff not in a section, should stay in chapter.</p>
+        <section class="this one doesn't move">
+            <p>Stuff that stays, as well</p>
+            <section class="key-equations">
+                <p>Hi, I'm a key equation</p>
+            </section>
+        </section>
+    </div>
+    <div data-type="page">
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section, too</p>
+        </section>
+    </div>
+</div>
+</body>
+</html>

--- a/cnxeasybake/tests/rulesets/match_escape.css
+++ b/cnxeasybake/tests/rulesets/match_escape.css
@@ -1,0 +1,37 @@
+/* Match functional pseudo class */
+div[data-type="page"] > div[data-type="document-title"] {
+    string-set: section-title content();
+  }
+  div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) {
+    attr-group-by: first-letter(content());
+  }
+  div[data-type="page"] span[data-type="term"]:match(\^[\^a-zA-Z]) {
+    attr-group-by: "";
+  }
+  div[data-type="page"] span[data-type="term"]:pass(2)::after {
+    content: content();
+    attr-group-by: attr(group-by);
+    container: span;
+    class: glossary-term;
+    move-to: gloss-term;
+  }
+  div[data-type="page"] span[data-type="term"]:pass(2)::after {
+    content: string(section-title);
+    container: a;
+    attr-href: "#" attr(id);
+    move-to: link;
+  }
+  div[data-type="page"] span[data-type="term"]:pass(2)::after {
+    content: pending(gloss-term) pending(link);
+    class: glossary-item;
+    move-to: eob-glossary;
+  }
+  body:pass(2)::after {
+    class: glossary;
+    content: pending(eob-glossary);
+    group-by: span, "span::attr(group-by)", nocase;
+  }
+  body > div.glossary > div.group-by:first-of-type > span.group-label:pass(3) {
+    content: "Symbol";
+  }
+  


### PR DESCRIPTION
Added test files identical to those of the other `match` test, except with `\` in front of characters that made the argument of `:match` an invalid css selector. The tests confirm that the output of using the escape characters and not doing so is exactly the same from easybake's perspective.

The reason for this work is on this issue: https://github.com/openstax/cnx-recipes/issues/415