### PR TITLE
Make cnx-easybake python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
-    #  - "3.3" Not yet
+  - "3.6"
 install:
   - ./scripts/setup
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
   - "3.6"
 install:
-  - ./scripts/setup
+  - CI=true ./scripts/setup
 script:
   - ./scripts/test
 after_success:

--- a/cnxeasybake/scripts/main.py
+++ b/cnxeasybake/scripts/main.py
@@ -20,7 +20,7 @@ def easybake(css_in, html_in=sys.stdin, html_out=sys.stdout, last_step=None,
     oven.bake(html_doc, last_step)
 
     # serialize out HTML
-    print (etree.tostring(html_doc, method="xml"), file=html_out)
+    print(etree.tostring(html_doc, method="xml"), file=html_out)
 
     # generate CSS coverage_file file
     if coverage_file:
@@ -48,7 +48,7 @@ def main(argv=None):
     parser.add_argument('-v', '--version', action="version",
                         version=__version__, help='Report the library version')
     parser.add_argument("css_rules",
-                        type=argparse.FileType('r'),
+                        type=argparse.FileType('rb'),
                         help="CSS3 ruleset stylesheet recipe")
     parser.add_argument("html_in", nargs="?",
                         type=argparse.FileType('r'),
@@ -84,8 +84,18 @@ def main(argv=None):
     # Debug option takes higher priority than quiet warnings option
     logger.setLevel(use_debug_log or use_quiet_log or logging.WARNING)
 
-    easybake(args.css_rules, args.html_in, args.html_out, args.stop_at,
-             args.coverage_file, args.use_repeatable_ids)
+    try:
+        easybake(args.css_rules, args.html_in, args.html_out, args.stop_at,
+                 args.coverage_file, args.use_repeatable_ids)
+    finally:
+        if args.css_rules:
+            args.css_rules.close()
+        if args.html_in:
+            args.html_in.close()
+        if args.html_out:
+            args.html_out.close()
+        if args.coverage_file:
+            args.coverage_file.close()
 
 
 if __name__ == "__main__":

--- a/cnxeasybake/tests/html/bad_declaration.log
+++ b/cnxeasybake/tests/html/bad_declaration.log
@@ -1,4 +1,4 @@
-cnx-easybake WARNING Invalid selector: div:nonsuch  (u'Unknown pseudo-class', u'nonsuch')
+cnx-easybake WARNING Invalid selector: div:nonsuch  ('Unknown pseudo-class', 'nonsuch')
 cnx-easybake DEBUG Passes: ['default']
 cnx-easybake DEBUG Rule (2): div 
 cnx-easybake DEBUG     default: string-set content()

--- a/cnxeasybake/tests/html/counter_styles.log
+++ b/cnxeasybake/tests/html/counter_styles.log
@@ -1,4 +1,4 @@
-cnx-easybake DEBUG Passes: ['0', u'2']
+cnx-easybake DEBUG Passes: ['0', '2']
 cnx-easybake DEBUG Rule (24): body::before 
 cnx-easybake DEBUG     0: content "Hint, the food is at item #" target-counter("burger", items)
 cnx-easybake DEBUG IdentToken as string: items

--- a/cnxeasybake/tests/html/index_divider.log
+++ b/cnxeasybake/tests/html/index_divider.log
@@ -1,4 +1,4 @@
-cnx-easybake DEBUG Passes: ['0', u'2']
+cnx-easybake DEBUG Passes: ['0', '2']
 cnx-easybake DEBUG Rule (1): div.index::before 
 cnx-easybake DEBUG     0: container span
 cnx-easybake DEBUG     0: class os-index-divider

--- a/cnxeasybake/tests/html/match.log
+++ b/cnxeasybake/tests/html/match.log
@@ -1,4 +1,4 @@
-cnx-easybake DEBUG Passes: ['0', u'2', u'3']
+cnx-easybake DEBUG Passes: ['0', '2', '3']
 cnx-easybake DEBUG Rule (2): div[data-type="page"] > div[data-type="document-title"] 
 cnx-easybake DEBUG     0: string-set section-title content()
 cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(^[a-zA-Z]) 

--- a/cnxeasybake/tests/html/match_escape.log
+++ b/cnxeasybake/tests/html/match_escape.log
@@ -1,4 +1,4 @@
-cnx-easybake DEBUG Passes: ['0', u'2', u'3']
+cnx-easybake DEBUG Passes: ['0', '2', '3']
 cnx-easybake DEBUG Rule (2): div[data-type="page"] > div[data-type="document-title"] 
 cnx-easybake DEBUG     0: string-set section-title content()
 cnx-easybake DEBUG Rule (5): div[data-type="page"] span[data-type="term"]:match(\^[a-zA-Z]) 

--- a/cnxeasybake/tests/html/two_pass.log
+++ b/cnxeasybake/tests/html/two_pass.log
@@ -1,4 +1,4 @@
-cnx-easybake DEBUG Passes: [u'counter(mine)', u'first', u'second']
+cnx-easybake DEBUG Passes: ['counter(mine)', 'first', 'second']
 cnx-easybake DEBUG Rule (12): :pass(counter(mine)) body::after 
 cnx-easybake DEBUG     counter(mine): content string(onestring)
 cnx-easybake DEBUG IdentToken as string: onestring

--- a/cnxeasybake/tests/test_cli.py
+++ b/cnxeasybake/tests/test_cli.py
@@ -16,6 +16,9 @@ from contextlib import contextmanager
 from io import StringIO
 
 
+IS_PY3 = sys.version_info > (3,)
+
+
 # noqa from http://stackoverflow.com/questions/4219717/how-to-assert-output-with-nosetest-unittest-in-python
 @contextmanager
 def captured_output():
@@ -121,7 +124,11 @@ class CliTestCase(unittest.TestCase):
             stderr = str(err.getvalue())
 
         self.assertEqual(stdout, '')
-        self.assertIn("error: too few arguments", stderr)
+        if IS_PY3:
+            self.assertIn("the following arguments are required: css_rules",
+                          stderr)
+        else:
+            self.assertIn("error: too few arguments", stderr)
 
     def test_help(self):
         """Check help usage message."""
@@ -179,7 +186,7 @@ optional arguments:
             stdout = str(out.getvalue())
             stderr = str(err.getvalue())
 
-        coverage_expected = """SF:rulesets/clear.css
+        coverage_expected = b"""SF:rulesets/clear.css
 DA:2,0
 DA:6,0
 DA:2,1

--- a/cnxeasybake/tests/test_oven.py
+++ b/cnxeasybake/tests/test_oven.py
@@ -4,7 +4,10 @@ import unittest
 import os
 import tempfile
 from contextlib import contextmanager
-from StringIO import StringIO
+try:
+    from io import BytesIO as StringIO
+except ImportError:
+    from StringIO import StringIO
 
 
 @contextmanager
@@ -22,11 +25,11 @@ HTML = '''<html xmlns="http://www.w3.org/1999/xhtml"><head><title>example</title
 </body></html>
 '''
 
-CSS = 'div { copy-to: end-of-chapter;}'
+CSS = b'div { copy-to: end-of-chapter;}'
 
-BAD_CSS = 'not a selector {}'
+BAD_CSS = b'not a selector {}'
 
-CSS_TWO_STEP = '''div[data-type="copy-me"] { step: 1; copy-to: "end-of-chapter" }
+CSS_TWO_STEP = b'''div[data-type="copy-me"] { step: 1; copy-to: "end-of-chapter" }
 div[data-type="book"]::after { step: 1; content: pending("end-of-chapter")}
 div[data-type="book"]::after {step: 5; content: "Here is a later step" }
 '''

--- a/cnxeasybake/tests/test_rulesets.py
+++ b/cnxeasybake/tests/test_rulesets.py
@@ -71,7 +71,7 @@ class RulesetTestCase(unittest.TestCase):
             header = []
             logs = []
             desc = None
-            with open('{}.css'.format(filename_no_ext), 'rb') as f_css:
+            with open('{}.css'.format(filename_no_ext), 'r') as f_css:
                 for line in f_css:
                     if line.startswith('/* '):
                         header.append(line[3:-3])
@@ -103,7 +103,7 @@ class RulesetTestCase(unittest.TestCase):
     @classmethod
     def create_test(cls, css, html, baked_html, desc, logs):
         """Create a specific ruleset test."""
-        @mock.patch('cnxeasybake.oven.uuid4', uuids.next)
+        @mock.patch('cnxeasybake.oven.uuid4', lambda: next(uuids))
         def run_test(self):
             element = etree.XML(html)
             oven = Oven(css)

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -e
 
-pythonMajorVersion=$(python --version 2>&1 | sed 's/.* \([0-9]\).*/\1/')
-
-if [ ${pythonMajorVersion} -ne "2" ]; then
-  echo "ERROR: Expected python 2 to be the version when running `python` but got ${pythonMajorVersion}"
-  exit 1
-fi
-
 echo "Step 1/2: Setting up a python virtualenv (if not already in one)"
 if [ ! "${CI}" = "true" ] # Skip when running Travis
 then

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import versioneer
 install_requires = (
     'cssselect',
     'cnx-cssselect2',  # importable as cssselect2
-    'tinycss2',
+    'tinycss2<1.0.0',  # 1.0.0 does not support python 2.x anymore
     'lxml',
     'PyICU==1.9.8;platform_system=="Darwin"',  # FIXME link/symbol prob OSX
     'PyICU',


### PR DESCRIPTION
This is part of the baked pdf work.  In order to bake a book in [neb](https://github.com/openstax/nebuchadnezzar), we want to import code from cnx-easybake.  neb uses python 3, so cnx-easybake needs to be upgraded for neb to be able to use it.
This should not affect existing users of cnx-easybake.

---

- Make cnx-easybake python 3 compatible

  - Fix code where python 3 expects either bytes or unicode string:
    - create a log function in oven.py to ensure we pass a `str` to
      `logger.log`;
    - update `__str__` to output a unicode string in python 3 and bytes in
      python 2;
    - change `open()` for files to specify the mode "r" or "rb" depending
      on what the code expects.
  
  - Close all the open files when `easybake` CLI is called.  The warnings
    are:
  
  ```
  /home/karen/src/cnx-easybake/cnxeasybake/tests/test_cli.py:66: ResourceWarning: unclosed file <_io.BufferedReader name='rulesets/empty.css'>
    self.target(args)
  /home/karen/src/cnx-easybake/cnxeasybake/tests/test_cli.py:66: ResourceWarning: unclosed file <_io.TextIOWrapper name='html/empty_raw.html' mode='r' encoding='UTF-8'>
    self.target(args)
  /home/karen/src/cnx-easybake/cnxeasybake/tests/test_cli.py:66: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
    self.target(args)
  ```
  
  - Import `io.BytesIO` in python 3 instead of `StringIO.StringIO` because
    the module has moved.
  
  - In test_rulesets.py, change the uuid generator from `uuids.next` to
    `next(uuids)` because `.next` doesn't exist in python 3.

- Update .travis.yml to include testing with py3.6

  Now that we updated the code to work with python 3, we need to make sure
  the code continues to work in python 3 by updating travis to run tests
  in python 2 and python 3.

- Install tinycss2<1.0.0 for py2 support

  tinycss2 1.0.0 removed support for python 2.x.

- Set CI=true when running ./script/setup on travis

  Travis already sets up the correct environment for us to install the
  package so there is no need to run virtualenv inside that.

- Remove python 2 check in scripts/setup

  There is a version check in scripts/setup for python to make sure it's
  python 2.  We have now made the code python 3 compatible so this check
  is no longer necessary.
