### PR TITLE
Fix unicode encode error in TargetVal.__str__

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -114,14 +114,16 @@ class TargetVal():
     def __unicode__(self):
         """Unicode value."""
         if self.vtype == 'counters':
-            r = str(self.collator.lookup(self.vtype,
-                                         (self.vname, self.vstyle),
-                                         self.el_id))
+            r = self.collator.lookup(self.vtype,
+                                     (self.vname, self.vstyle),
+                                     self.el_id)
         else:
-            r = str(self.collator.lookup(self.vtype,
-                                         self.vname,
-                                         self.el_id))
-        if not IS_PY3:
+            r = self.collator.lookup(self.vtype,
+                                     self.vname,
+                                     self.el_id)
+        if not isinstance(r, basestring):
+            r = str(r)
+        if isinstance(r, bytes):
             r = r.decode('utf-8')
         return r
 

--- a/cnxeasybake/tests/test_oven.py
+++ b/cnxeasybake/tests/test_oven.py
@@ -8,6 +8,10 @@ try:
     from io import BytesIO as StringIO
 except ImportError:
     from StringIO import StringIO
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 @contextmanager
@@ -119,3 +123,26 @@ class OvenBakeTest(unittest.TestCase):
         html_doc = etree.XML(HTML)
 
         oven.bake(html_doc)
+
+
+class TargetValTest(unittest.TestCase):
+    @property
+    def target_cls(self):
+        from ..oven import TargetVal
+        return TargetVal
+
+    def test___str__(self):
+        """Test TargetVal.__str__ can handle all kinds of values"""
+        collator = mock.Mock()
+
+        test_inputs_outputs = (
+            (16, '16'),
+            (b'\xc4\x86wiczenie', 'Ćwiczenie'),
+            (u'Ćwiczenie', 'Ćwiczenie'),
+            (None, 'None'),
+        )
+
+        for test_input, test_output in test_inputs_outputs:
+            collator.lookup.return_value = test_input
+            tv = self.target_cls(collator, None, None, None)
+            self.assertEqual(str(tv), test_output)


### PR DESCRIPTION
When baking a polish book on staging, we encounter a
`UnicodeEncodeError`:

```
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/tasks.py", line 31, in __call__
    return super(PyramidAwareTask, self).__call__(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/db.py", line 74, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/subscribers.py", line 167, in baking_processor
    bake(binder, recipe_id, publisher, message, cursor=cursor)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/db.py", line 70, in wrapped
    return func(*args, **kwargs)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxpublishing/bake.py", line 73, in bake
    binder = collate_models(binder, ruleset=recipe, includes=includes)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxepub/collation.py", line 68, in collate
    easybake(ruleset, raw_html, collated_html)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxepub/collation.py", line 38, in easybake
    oven.bake(html)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxeasybake/oven.py", line 345, in bake
    strval = u''.join([u'{}'.format(s) for s in value])
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/cnxeasybake/oven.py", line 123, in __unicode__
    self.el_id))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0106' in position 0: ordinal not in range(128)
```

After some investigation, this error actually comes from `TargetVal.__str__`:

```
r = str(self.collator.lookup(self.vtype,
                             self.vname,
                             self.el_id))
```

`self.collator.lookup` returned `Ćwiczenie 1.58` (in unicode) causing python 2
to error (python 3 is fine though).

Change `TargetVal.__str__` to only do `str()` on values that are not unicode or
string.

Fix openstax/cnx#302