### PR TITLE
Fix py3 cnx-easybake script output invalid html

### DIFF
--- a/cnxeasybake/scripts/main.py
+++ b/cnxeasybake/scripts/main.py
@@ -20,7 +20,8 @@ def easybake(css_in, html_in=sys.stdin, html_out=sys.stdout, last_step=None,
     oven.bake(html_doc, last_step)
 
     # serialize out HTML
-    print(etree.tostring(html_doc, method="xml"), file=html_out)
+    print(etree.tostring(html_doc, method="xml").decode('utf-8'),
+          file=html_out)
 
     # generate CSS coverage_file file
     if coverage_file:

--- a/cnxeasybake/tests/test_cli.py
+++ b/cnxeasybake/tests/test_cli.py
@@ -62,8 +62,10 @@ class CliTestCase(unittest.TestCase):
         """Call cli with basic successful run."""
         os.chdir(here)
         with captured_output() as (out, err):
-            args = ['rulesets/empty.css', 'html/empty_raw.html', '/dev/null']
-            self.target(args)
+            with tempfile.NamedTemporaryFile() as tf:
+                args = ['rulesets/empty.css', 'html/empty_raw.html', tf.name]
+                self.target(args)
+                self.assertEqual(tf.file.read(5), b'<html')
             stdout = str(out.getvalue())
             stderr = str(err.getvalue())
 


### PR DESCRIPTION
For python 3, cnx-easybake script outputs `b'<html` instead of just
`<html`, causing the browser to show this error:

```
error on line 1 at column 1: Document is empty
```

The code that outputs the html is:

```
    print(etree.tostring(html_doc, method="xml"), file=html_out)
```

To make this work for both python2 and python3, decode the output of
`etree.tostring` so it writes the html correctly to the file.