### PR TITLE
Provide a containerized install of this project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+COPY ./ /src
+WORKDIR /src
+
+RUN set -x \
+    && python -m pip install -r requirements/main.txt -r requirements/test.txt
+RUN set -x && python -m pip install -e "."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,19 @@
 pipeline {
   agent { label 'docker' }
   stages {
+    stage('Build') {
+      steps {
+        sh "docker build -t openstax/cnx-easybake:${GIT_COMMIT} ."
+      }
+    }
+    stage('Publish Dev Container') {
+      steps {
+        // 'docker-registry' is defined in Jenkins under credentials
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker push openstax/cnx-easybake:${GIT_COMMIT}"
+        }
+      }
+    }
     stage('Publish Release') {
       when { buildingTag() }
       environment {
@@ -11,6 +24,12 @@ pipeline {
         TWINE_PASSWORD = "${TWINE_CREDS_PSW}"
       }
       steps {
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker tag openstax/cnx-easybake:${GIT_COMMIT} openstax/cnx-easybake:${release}"
+          sh "docker tag openstax/cnx-easybake:${GIT_COMMIT} openstax/cnx-easybake:latest"
+          sh "docker push openstax/cnx-easybake:${release}"
+          sh "docker push openstax/cnx-easybake:latest"
+        }
         // Install git, run the python build, upload to pypi, and cleanup
         sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}:/src:rw --workdir /src python:2-slim /bin/bash -c \"apt-get update && apt-get install -y git && pip install -q twine && python setup.py bdist_wheel --universal && twine upload dist/* && rm -rf dist build *.egg-info versioneer.pyc\""
       }

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,0 +1,7 @@
+cssselect
+cnx-cssselect2
+tinycss2<1.0.0
+lxml
+# FIXME link/symbol prob OSX
+PyICU==1.9.8;platform_system=="Darwin"
+PyICU

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,2 @@
+mock
+testfixtures

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,27 @@ This software is subject to the provisions of the
 GNU AFFERO GENERAL PUBLIC LICENSE Version 3.0 (AGPL).
 See LICENSE.txt for details.
 """
+import os
+
 from setuptools import setup, find_packages
 import versioneer
 
-install_requires = (
-    'cssselect',
-    'cnx-cssselect2',  # importable as cssselect2
-    'tinycss2<1.0.0',  # 1.0.0 does not support python 2.x anymore
-    'lxml',
-    'PyICU==1.9.8;platform_system=="Darwin"',  # FIXME link/symbol prob OSX
-    'PyICU',
-    )
 
-tests_require = (
-    'testfixtures', 'mock',
-    )
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def read_from_requirements_txt(filepath):
+    f = os.path.join(here, filepath)
+    with open(f) as fb:
+        return tuple([x.strip() for x in fb if not x.strip().startswith('#')])
+
+
+install_requires = read_from_requirements_txt('requirements/main.txt')
+tests_require = read_from_requirements_txt('requirements/test.txt')
+extras_require = {
+    'test': tests_require,
+}
+
 
 setup(
     name='cnx-easybake',


### PR DESCRIPTION
This gives this project a containerized space to work within.

This is only a step in the general direction of containerizing this project. Other elements include testing and development, which are not touched by these changes.

The near-term intended use for this work is within cnx-recipes. The hope is that is encapsulated component will cut down on installation problems (most notably the issue with installing PyICU).

(Please note that jenkins-dev is having some issues not related to this project. So please ignore its failures for now.)