### PR TITLE
Add twine check on travis

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -14,4 +14,11 @@ pep8 --max-line-length=1000 "${GIT_ROOT}"/cnxeasybake/tests
 
 coverage run --source=cnxeasybake setup.py test
 
+if [ "${CI}" = "true" ]
+then
+  python setup.py bdist_wheel --universal
+  pip install twine
+  twine check dist/*
+fi
+
 # Note: deactivate is not necessary because the virtualenv is deactivated at the end of the script


### PR DESCRIPTION
To avoid tagging and then getting rejected by pypi, we're running twine
check on travis so it will catch all the errors before we upload to
pypi.