### PR TITLE
Remove upload pypi step in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,6 @@ pipeline {
     stage('Publish Release') {
       when { buildingTag() }
       environment {
-        TWINE_CREDS = credentials('pypi-openstax-creds')
-        TWINE_USERNAME = "${TWINE_CREDS_USR}"
-        TWINE_PASSWORD = "${TWINE_CREDS_PSW}"
         release = getVersion()
       }
       steps {
@@ -31,8 +28,6 @@ pipeline {
           sh "docker push openstax/cnx-easybake:${release}"
           sh "docker push openstax/cnx-easybake:latest"
         }
-        // Install git, run the python build, upload to pypi, and cleanup
-        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}:/src:rw --workdir /src python:2-slim /bin/bash -c \"apt-get update && apt-get install -y git && pip install -q twine && python setup.py bdist_wheel --universal && twine upload dist/* && rm -rf dist build *.egg-info versioneer.pyc\""
       }
     }
   }


### PR DESCRIPTION
We continue to have problems with jenkins-dev because of the filesystem being
full.  This means either poking devops or uploading to pypi manually.  To avoid
this problem, we are going to use this concourse pipeline to upload to pypi
instead:

https://github.com/openstax/concourse-pipelines/tree/master/pypi-dist-upload

Concourse is better at cleaning up so hopefully we won't see the same problem.